### PR TITLE
handle cmake depends properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_THREAD_PREFERE_PTHREAD)
 set(THREADS_PREFERE_PTHREAD_FLAG)
 find_package(Threads REQUIRED)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 find_package(evo-mbed-tools REQUIRED)
 
 add_compile_options(-std=c++14 -DROS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,13 @@ find_package(catkin REQUIRED roscpp)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
+set(CMAKE_THREAD_PREFERE_PTHREAD)
+set(THREADS_PREFERE_PTHREAD_FLAG)
+find_package(Threads REQUIRED)
+
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+find_package(evo-mbed-tools REQUIRED)
+
 add_compile_options(-std=c++14 -DROS)
 
 
@@ -136,8 +143,8 @@ add_executable(${PROJECT_NAME}_test_node
 
 target_link_libraries(${PROJECT_NAME}_test_node
   ${PROJECT_NAME}
-  evo-mbed-tools
-  pthread
+  evo-mbed-tools::evo-mbed-tools
+  Threads::Threads
 )
 
 

--- a/cmake/Findevo-mbed-tools.cmake
+++ b/cmake/Findevo-mbed-tools.cmake
@@ -1,7 +1,7 @@
 include(FindPackageHandleStandardArgs)
 
-find_package(evo-mbed-tools NO_MODULE)
-if(DEFINED evo-mbed-tools_FOUND)
+find_package(evo-mbed-tools QUIET NO_MODULE)
+if(DEFINED evo-mbed-tools_FOUND AND evo-mbed-tools_FOUND)
 	find_package_handle_standard_args(evo-mbed-tools CONFIG_MODE)
 	return()
 endif()
@@ -11,11 +11,11 @@ find_path(EVO_MBED_TOOLS_INCLUDE NAMES evo_mbed
 	)
 
 if(DEFINED EVO_MBED_TOOLS_INCLUDE)
-	file(READ ${EVO_MBED_TOOLS_INCLUDE}/Version.h version_file)
+	file(READ "${EVO_MBED_TOOLS_INCLUDE}/evo_mbed/Version.h" version_file)
 
-	string(REGEX MATCH "EVO_MBED_TOOLS_VER\s+\"(\d\.\d\.\d)\"" _ ${version_file})
-	set(evo-mbed-tools_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL)
-	set(evo-mbed-tools_INCLUDE_DIR ${EVO_MBED_TOOLS_INCLUDE} CACHE INTERNAL)
+	string(REGEX MATCH "EVO_MBED_TOOLS_VER[ \t]*\"([0-9]+.[0-9]+.[0-9]+)\"" _ ${version_file})
+	set(evo-mbed-tools_VERSION "${CMAKE_MATCH_1}")
+	set(evo-mbed-tools_INCLUDE_DIR "${EVO_MBED_TOOLS_INCLUDE}")
 endif()
 
 find_library(LIBEVO_MBED_TOOLS NAMES
@@ -29,14 +29,16 @@ find_library(LIBEVO_MBED_TOOLS NAMES
 if(DEFINED LIBEVO_MBED_TOOLS AND NOT TARGET evo-mbed-tools::evo-mbed-tools)
 	add_library(evo-mbed-tools::evo-mbed-tools UNKNOWN IMPORTED)
 	set_target_properties(evo-mbed-tools::evo-mbed-tools PROPERTIES
-		IMPORTED_LOCATION ${LIBEVO_MBED_TOOLS}
+		IMPORTED_LOCATION "${LIBEVO_MBED_TOOLS}"
 		)
 
-	set(evo-mbed-tools_LIBRARY ${LIBEVO_MBED_TOOLS} CACHE INTERNAL)
+	set(evo-mbed-tools_LIBRARY "${LIBEVO_MBED_TOOLS}")
 endif()
 
 find_package_handle_standard_args(evo-mbed-tools
-	REQUIRED_VARS evo-mbed-tools_INCLUDE_DIR evo-mbed-tools_LIBRARY
+	REQUIRED_VARS 
+		evo-mbed-tools_LIBRARY 
+		evo-mbed-tools_INCLUDE_DIR
 	VERSION_VAR evo-mbed-tools_VERSION
 	)
 

--- a/cmake/Findevo-mbed-tools.cmake
+++ b/cmake/Findevo-mbed-tools.cmake
@@ -1,0 +1,47 @@
+include(FindPackageHandleStandardArgs)
+
+find_package(evo-mbed-tools NO_MODULE)
+if(DEFINED evo-mbed-tools_FOUND)
+	find_package_handle_standard_args(evo-mbed-tools CONFIG_MODE)
+	return()
+endif()
+
+find_path(EVO_MBED_TOOLS_INCLUDE NAMES evo_mbed
+	PATHS /usr/include/evo_mbed
+	)
+
+if(DEFINED EVO_MBED_TOOLS_INCLUDE)
+	file(READ ${EVO_MBED_TOOLS_INCLUDE}/Version.h version_file)
+
+	string(REGEX MATCH "EVO_MBED_TOOLS_VER\s+\"(\d\.\d\.\d)\"" _ ${version_file})
+	set(evo-mbed-tools_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL)
+	set(evo-mbed-tools_INCLUDE_DIR ${EVO_MBED_TOOLS_INCLUDE} CACHE INTERNAL)
+endif()
+
+find_library(LIBEVO_MBED_TOOLS NAMES
+	evo-mbed-tools
+	libevo-mbed-tools
+	libevo-mbed-tools.so
+	libevo-mbed-tools.so.1
+	PATHS /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/libevo-mbed-tools.so.1
+	)
+
+if(DEFINED LIBEVO_MBED_TOOLS AND NOT TARGET evo-mbed-tools::evo-mbed-tools)
+	add_library(evo-mbed-tools::evo-mbed-tools UNKNOWN IMPORTED)
+	set_target_properties(evo-mbed-tools::evo-mbed-tools PROPERTIES
+		IMPORTED_LOCATION ${LIBEVO_MBED_TOOLS}
+		)
+
+	set(evo-mbed-tools_LIBRARY ${LIBEVO_MBED_TOOLS} CACHE INTERNAL)
+endif()
+
+find_package_handle_standard_args(evo-mbed-tools
+	REQUIRED_VARS evo-mbed-tools_INCLUDE_DIR evo-mbed-tools_LIBRARY
+	VERSION_VAR evo-mbed-tools_VERSION
+	)
+
+mark_as_advanced(evo-mbed-tools_INCLUDE_DIR
+	evo-mbed-tools_LIBRARY
+	evo-mbed-tools_VERSION
+	)
+


### PR DESCRIPTION
Handle CMake dependency resolution correctly and backwards compatible to none-config libevo-mbed-tools build